### PR TITLE
Switch to ticker_v2 channel

### DIFF
--- a/kalshi_bot/kalshi_client.py
+++ b/kalshi_bot/kalshi_client.py
@@ -70,7 +70,7 @@ class KalshiClient:
 		"id": 1,
 		"cmd": "subscribe",
 		"params": {
-		"channels": ["ticker", "orderbook_delta"],
+                "channels": ["ticker_v2", "orderbook_delta"],
 		"market_ticker": market_ticker
    			 }
             }


### PR DESCRIPTION
## Summary
- update Kalshi websocket subscribe code to use `ticker_v2` channel

## Testing
- `python -m py_compile kalshi_bot/kalshi_client.py`
- `python -m py_compile btc_aggregator.py coinbase_price_feed.py coinbase_test_price_feed.py kalshi_bot/__init__.py test_aggregator.py test_kalshi_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6851fbcac27083208ad0f4d939efe3bf