### PR TITLE
Add helper for periodic BTC price file

### DIFF
--- a/btc_price_writer.py
+++ b/btc_price_writer.py
@@ -1,0 +1,25 @@
+import asyncio
+import json
+from btc_aggregator import BTCPriceAggregator
+
+
+async def write_price(aggregator: BTCPriceAggregator, interval: int = 5, path: str = "btc_price.json"):
+    """Periodically write the aggregated BTC price to a JSON file."""
+    while True:
+        await asyncio.sleep(interval)
+        price = aggregator.get_current_average_price()
+        if price is None:
+            continue
+        with open(path, "w") as f:
+            json.dump({"price": price}, f)
+
+
+async def main():
+    aggregator = BTCPriceAggregator()
+    # Start the price feeds in the background
+    asyncio.create_task(aggregator.start())
+    await write_price(aggregator)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `btc_price_writer.py` helper script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852047ec7c483208778da1c5b2c10e6